### PR TITLE
Fix README video link spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the game you can play on https://blackfriday.cns.me/
 
-Or watch our video about it[![Video](https://img.youtube.com/vi/Ij7IKrSFqas/0.jpg)](https://www.youtube.com/watch?v=Ij7IKrSFqas)
+Or watch our video about it [![Video](https://img.youtube.com/vi/Ij7IKrSFqas/0.jpg)](https://www.youtube.com/watch?v=Ij7IKrSFqas)
 
 # deploy
 


### PR DESCRIPTION
## Summary
- ensure the video link in README has a leading space

## Testing
- `markdownlint README.md`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68401e6b23a4832aaed9cd5c3d3d1f8f