### PR TITLE
Fix duplicate jsoneditor script

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,6 @@
       crossorigin="anonymous"
     ></script>
     <link rel="stylesheet" type="text/scss" href="./styles.scss" />
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
   </head>
   <body>
     <h1>Black Friday</h1>


### PR DESCRIPTION
## Summary
- remove second jsoneditor inclusion in docs/index.html

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node` script to count `jsoneditor` inclusions

------
https://chatgpt.com/codex/tasks/task_e_68401e750634832abbc26c0978e872e1